### PR TITLE
fix: solve issue with unsync row data

### DIFF
--- a/lib/timeline/Core.js
+++ b/lib/timeline/Core.js
@@ -287,14 +287,19 @@ class Core {
         this.dom.centerContainer.addEventListener(wheelType, onMouseWheel.bind(this), false);
         this.dom.top.addEventListener(wheelType, onMouseWheel.bind(this), false);
         this.dom.bottom.addEventListener(wheelType, onMouseWheel.bind(this), false);
-
+        let timerId;
 
         /**
          *
          * @param {scroll} event
          */
-        function onMouseScrollSide(event) {
+        function onScrollMethod(event) {
             if (!me.options.verticalScroll) return;
+
+            if (me._isProgramaticallyScrolled) {
+                me._isProgramaticallyScrolled = false;
+                return;
+            }
 
             event.preventDefault();
             if (me.isActive()) {
@@ -303,6 +308,20 @@ class Core {
                 me._redraw();
                 me.emit('scrollSide', event);
             }
+        }
+
+        /**
+         *
+         * @param {scroll} event
+         */
+        function onMouseScrollSide(event) {
+            if (timerId) {
+                clearTimeout(timerId);
+            }
+            onScrollMethod(event);
+            timerId = setTimeout(() => {
+                onScrollMethod(event);
+            }, 100)
         }
 
         this.dom.left.parentNode.addEventListener('scroll', onMouseScrollSide.bind(this));


### PR DESCRIPTION
VisTimeline has an issue with sync the left and right parts of a chart when you use scroll or scrollbar. In some cases, the result (right part) isn't aligned correctly with the data column (left part). 

The error you can saw on this video:
https://user-images.githubusercontent.com/66253914/131107205-f41413cf-8ca6-43a3-a137-64c6b6e32dd5.mov

Version after changes:
https://user-images.githubusercontent.com/66253914/131107242-1a29fb5d-ea25-4be7-8daf-a1cb6c6b63c0.mov